### PR TITLE
target[key] is only overridden if the current value is undefined.

### DIFF
--- a/tasks/nightwatch.js
+++ b/tasks/nightwatch.js
@@ -27,7 +27,7 @@ module.exports = function(grunt) {
           if (!_.isArray(value) && _.isObject(value)) {
             target[key] = mergeVars(target[key], value);
           } else {
-            target[key] = replaceEnv(value);
+            target[key] = replaceEnv(value || target[key]);
           }
         });
       });


### PR DESCRIPTION
target[key] is only overridden if the current value is undefined. In the case of defaults they will never be overridden as they are never undefined.
