### PR TITLE
Fix done callback was never called.

### DIFF
--- a/tasks/nightwatch.js
+++ b/tasks/nightwatch.js
@@ -179,14 +179,15 @@ module.exports = function(grunt) {
               grunt.log.error('There was an error while running the test.');
             }
             selenium.stopServer();
+            options.doneCallback();
           });
         });
       } else {
-        runner.run(setup.src_folders, setup.test_settings[group], config);
+        runner.run(setup.src_folders, setup.test_settings[group], config, options.doneCallback);
       }
     }
 
-    this.async();
+    options.doneCallback = this.async();
 
     // if enabled, there are two scenarios:
     // - jar_path exists, then use it


### PR DESCRIPTION
I was unable to chain tasks using grunt-nightwatch.
The `done` callback was never called so the task was unable to have another task after.

http://gruntjs.com/creating-tasks#why-doesn-t-my-asynchronous-task-complete

I may forgot some edge case, but this fix works for me.
