### PR TITLE
Merge group test settings specified in Grunt config

### DIFF
--- a/tasks/nightwatch.js
+++ b/tasks/nightwatch.js
@@ -49,7 +49,7 @@ module.exports = function(grunt) {
     $.mergeVars(defaults.test_settings, settings.test_settings['default'] || {});
 
     // load the target options with the global and target defaults
-    $.mergeVars(settings.test_settings[group], defaults.test_settings, options.test_settings, _.pick(options, settings_opts), _.pick(options[group] || {}, settings_opts));
+    $.mergeVars(settings.test_settings[group], options.test_settings[group], defaults.test_settings, options.test_settings, _.pick(options, settings_opts), _.pick(options[group] || {}, settings_opts));
 
     // override the global task options if needed
     $.mergeVars(options, _.pick(options[group] || {}, fake_opts));


### PR DESCRIPTION
Noticed a small issue the other day after the release of 0.2.4 where settings overrides for a group specified in grunt config weren't making it to tests. Specifically, I was overriding "globals" for an environment, but these weren't available via browser.globals for my environment test run, e.g.:

```
      options: {
        "settings": {
            ...
          }
        },
        "test_settings": {
          "default": {
            "globals": {
              "foo": "value1"
            }
          },
          "other_env": {
            "globals": {
              "foo": "value2"
            },
          },
```

With the above config in my Gruntfile, I'd end up with a browser.globals of {}. Patch below merges test_settings for a selected group into the big settings hash. 

Would appreciate a sanity check here, just in case I'm overlooking something about how settings from other sources (e.g. nightwatch.json) are merged.
