### PR TITLE
Use spawn instead of exec to avoid escaping command-line arguments.

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -26,7 +26,7 @@ module.exports = function(grunt) {
         settings: settings
       });
 
-      var cmd = ['node', path.join(__dirname, 'background.js'), '--', encodeURIComponent(data)];
+      var cmd = [path.join(__dirname, 'background.js'), '--', encodeURIComponent(data)];
 
       $.verbose.ok('Settings for ' + group.join(', '));
       $.verbose.writeln(JSON.stringify(settings));
@@ -35,10 +35,7 @@ module.exports = function(grunt) {
         child.kill();
       }
 
-      child = child_process.exec(cmd.join(' '), function() {
-        // do nothing
-      });
-
+      child = child_process.spawn('node', cmd);
       child.on('exit', done);
       child.stdout.pipe(process.stdout);
       byline(child.stderr).on('data', function(line) {

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -1,7 +1,8 @@
 'use strict';
 
 var path = require('path'),
-    child_process = require('child_process');
+    child_process = require('child_process'),
+    byline = require('byline');
 
 module.exports = function(grunt) {
   var $ = require('./functions')(grunt),
@@ -40,7 +41,8 @@ module.exports = function(grunt) {
 
       child.on('exit', done);
       child.stdout.pipe(process.stdout);
-      child.stderr.on('data', function(err) {
+      byline(child.stderr).on('data', function(line) {
+        var err = line.toString();
         if (err.indexOf('Error:') > -1) {
           err = err.match(/Error:\s*(.*?)\n/)[1];
         }

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   },
   "license": "MIT",
   "dependencies": {
+    "byline": "^4.2.1",
     "nightwatch": "^0.5.36"
   },
   "devDependencies": {


### PR DESCRIPTION
On our project, we have a `grunt-nightwatch` task running in a workspace subdirectory named "Web (Pull Requests)".

As you can imagine, this plays hell with `exec`'s behavior of calling `sh`. Both because there are spaces *and* parenthesis in the pathname.

Use `spawn` instead to avoid all this. But spawn means getting the unbuffered stream directly, so use `byline` to retain line-by-line error parsing.

I've given this a kick locally, but dang is `grunt-nightwatch` hard to test without credentials. 