### PR TITLE
fix error parsing

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -44,7 +44,7 @@ module.exports = function(grunt) {
       byline(child.stderr).on('data', function(line) {
         var err = line.toString();
         if (err.indexOf('Error:') > -1) {
-          err = err.match(/Error:\s*(.*?)\n/)[1];
+          err = err.match(/Error:\s*(.*?)$/)[1];
         }
 
         done(err);


### PR DESCRIPTION
Hi,

nightwatch sderr output was beng parsed with regexp that expects a newline at the end, but nightwatch stdout does not contain one, resulting in `Fatal error: Cannot read property '1' of null` error when trying to print an error.
Fixed by having regex match to end of string