### PR TITLE
Merge the tests with the test_settings from grunt config.  don't overwrite them

### DIFF
--- a/tasks/nightwatch.js
+++ b/tasks/nightwatch.js
@@ -19,7 +19,7 @@ module.exports = function(grunt) {
     }
 
     config.argv =  grunt.cli.options;
-    config.test_settings = tests;
+    config.test_settings = _.merge(config.test_settings, tests);
 
     nwrun(config, done);
   });


### PR DESCRIPTION
Without this line, the test_settings I have defined in the config get wiped away with the documented way to define multitask targets.

I use test_settings to define some specific selenium options.  I am testing a custom Chromium build, and that build also builds a custom chromedriver.  Without being able to use desired_capabilities in test_settings.default, I can't point selenium to the proper browser binary to start.

Instead, the test_settings are wiped away and the target tests are loaded in the default browser:  firefox.  Unfortunately, firefox is not my most desired capability for my test :/


```
        nightwatch: {      
            options: {     
                standalone: true,
                jar_version: '2.48.2',
                jar_path: 'server.jar',
                jar_url: 'http://selenium-release.storage.googleapis.com/2.48/selenium-server-standalone-2.48.2.jar',      
                output_folder: 'report',
                selenium: {
                    cli_args: {
                        'webdriver.chrome.driver': process.env.WEBDRIVER_BINARY_PATH
                    }
                },
                test_settings: {       
                    default: {     
                        launch_url: 'http://localhost:4444/wd/hub',
                        silent: true,
                        disable_colors: false,
                        screenshots: {     
                            enabled: false,
                            path: ''       
                        },
                        desiredCapabilities: {
                            browserName: 'chrome',     
                            platform: 'ANY',       
                            acceptSslCerts: true,      
                            javascriptEnabled: true,       
                            chromeOptions: {       
                                binary: process.env.MAELSTROM_BINARY       
                            }
                        }
                    }
                }      
            },     
            a: {        
                src_folders: ['test/a']       
            },     
            b: {      
                src_folders: ['test/b']
            }
        },
```